### PR TITLE
Update the API root to the new Renac URI

### DIFF
--- a/custom_components/renac/manifest.json
+++ b/custom_components/renac/manifest.json
@@ -4,6 +4,6 @@
   "codeowners": ["ghelin"],
   "documentation": "https://github.com/gastush/ha-renac",
   "iot_class": "cloud_polling",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "loggers": ["custom_components.renac"]
 }

--- a/custom_components/renac/sensor.py
+++ b/custom_components/renac/sensor.py
@@ -21,7 +21,7 @@ CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_EQUIPSN = "equipment_serial"
 
-API_ROOT = "http://153.le-pv.com:8082/api/"
+API_ROOT = "https://sec.bg.renacpower.cn:8084/api/"
 
 class Updater():
     def __init__(self, emailSn, equipSn):


### PR DESCRIPTION
Renac changed the URI to the API server. It now points to https://sec.bg.renacpower.cn:8084/api/