### PR TITLE
Add the Token HTTP header to each request

### DIFF
--- a/custom_components/renac/manifest.json
+++ b/custom_components/renac/manifest.json
@@ -4,6 +4,6 @@
   "codeowners": ["ghelin"],
   "documentation": "https://github.com/gastush/ha-renac",
   "iot_class": "cloud_polling",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "loggers": ["custom_components.renac"]
 }


### PR DESCRIPTION
Since the 29th of January some API calls are returning "null" results. This is due to the missing Token HTTP header which appear to be mandatory now. The value for this Token can be found in the response of the /login call.
No clue yet on how often this token changes or not. This may require implementing a fresh login sequence to get a new token.