### PR TITLE
Handle daily reset of statistics

### DIFF
--- a/custom_components/renac/entity.py
+++ b/custom_components/renac/entity.py
@@ -62,7 +62,7 @@ class RenacEntity(CoordinatorEntity[RenacCoordinator]):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, api.getSerial())},
             manufacturer="Renac",
-            model=api.fetch_field_value(coordinator.data, "model"),
+            model=data.model,
             name=data.name,
             hw_version=data.fwversion,
             serial_number=api.getSerial(),

--- a/custom_components/renac/manifest.json
+++ b/custom_components/renac/manifest.json
@@ -5,7 +5,7 @@
   "codeowners": ["ghelin"],
   "documentation": "https://github.com/gastush/ha-renac",
   "iot_class": "cloud_polling",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "loggers": ["custom_components.renac"],
-  "requirements": ["requests", "aiohttp", "pyrenac>=0.1.0"]
+  "requirements": ["requests", "aiohttp", "pyrenac>=0.1.2"]
 }

--- a/custom_components/renac/sensor.py
+++ b/custom_components/renac/sensor.py
@@ -324,12 +324,20 @@ class RenacSensor(RenacEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         all_data = self.coordinator.data
 
-        value = self.api.fetch_field_value(all_data, self.internal_key)
-        self._attr_native_value = value
         if self.daily_reset:
-            self._attr_last_reset = datetime.now().replace(
+            last_upload = self.api.fetch_field_value(all_data, "UPLOAD_TIME")
+            # Only consider the update if it was uploaded on the same day.
+            if datetime.fromisoformat(last_upload) >= datetime.now().replace(
                 hour=0, minute=0, second=0, microsecond=0
-            )
+            ):
+                value = self.api.fetch_field_value(all_data, self.internal_key)
+                self._attr_native_value = value
+                self._attr_last_reset = datetime.fromisoformat(last_upload).replace(
+                    hour=0, minute=0, second=0, microsecond=0
+                )
+        else:
+            value = self.api.fetch_field_value(all_data, self.internal_key)
+            self._attr_native_value = value
 
         self.async_write_ha_state()
 


### PR DESCRIPTION
The "today's energy" value is not reset to 0 at midnight anymore, but more around 5:20 (likely when the inverter wakes up) so this was causing the previous day stat to be accounted for wrongly... trying to fix this by only taking the value if the upload date is post midnight on the same day